### PR TITLE
Exemplary setfile and task manifest to get stats for network interfaces

### DIFF
--- a/examples/setfiles/setfile_interfaces.json
+++ b/examples/setfiles/setfile_interfaces.json
@@ -1,0 +1,423 @@
+[
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifType"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.3",
+    "description": "the type of interface"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifMtu"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.4",
+    "description": "the size of the largest datagram"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifSpeed"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.5",
+    "description": "the interface's current bandwidth in bits per second"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifPhysAddress"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.6",
+    "description": "the interface's address at the protocol layer"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifAdminStatus"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.7",
+    "description": "the desired state of the interface"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOperStatus"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.8",
+    "description": "the current operational state of the interface"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifLastChange"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.9",
+    "description": "the value of sysUpTime at the time the interface entered its current operational state"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInOctets"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.10",
+    "description": "the total number of octets received on the interface, including framing characters"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInUcastPkts"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.11",
+    "description": "the number of subnetwork-unicast packets delivered to a higher-layer protocol"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInNUcastPkts"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.12",
+    "description": "the number of non-unicast (i.e., subnetwork- broadcast or subnetwork-multicast) packetsdelivered to a higher-layer protocol"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInDiscards"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.13",
+    "description": "the number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol."
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInErrors"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.14",
+    "description": "the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifInUnknownProtos"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.15",
+    "description": "the number of packets received via the interface which were discarded because of an unknown or unsupported protocol"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutOctets"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.16",
+    "description": "the total number of octets transmitted out of the interface, including framing characters"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutUcastPkts"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.17",
+    "description": "the total number of packets that higher-level protocols requested be transmitted to a subnetwork-unicast address, including those that were discarded or not sent"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutNUcastPkts"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.18",
+    "description": "the total number of packets that higher-level protocols requested be transmitted to a non-unicast (i.e., a subnetwork-broadcast or subnetwork-multicast) address, including those that were discarded or not sent"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutDiscards"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.19",
+    "description": "the number of outbound packets which were chosen to be discarded even though no errors had been detected to prevent their being transmitted"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutErrors"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.20",
+    "description": "the number of outbound packets that could not be transmitted because of errors"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifOutQLen"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.21",
+    "description": "the length of the output packet queue (in packets)"
+  },
+  {
+    "mode": "walk",
+    "namespace": [
+      {
+        "source": "string",
+        "string": "interfaces"
+      },
+      {
+        "source": "snmp",
+        "name": "ifDescr",
+        "description": "the textual string containing information about the interface",
+        "OID": ".1.3.6.1.2.1.2.2.1.2"
+      },
+      {
+        "source": "string",
+        "string": "ifSpecific"
+      }
+    ],
+    "OID": ".1.3.6.1.2.1.2.2.1.22",
+    "description": "a reference to MIB definitions specific to the particular media being used to realize the interface"
+  }
+]
+

--- a/examples/tasks/task_interfaces.json
+++ b/examples/tasks/task_interfaces.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "30s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/snmp/interfaces/*/ifAdminStatus" : {},
+        "/intel/snmp/interfaces/*/ifInDiscards": {},
+        "/intel/snmp/interfaces/*/ifInErrors": {},
+        "/intel/snmp/interfaces/*/ifInNUcastPkts": {},
+        "/intel/snmp/interfaces/*/ifInOctets": {},
+        "/intel/snmp/interfaces/*/ifInUcastPkts": {},
+        "/intel/snmp/interfaces/*/ifInUnknownProtos": {},
+        "/intel/snmp/interfaces/*/ifLastChange": {},
+        "/intel/snmp/interfaces/*/ifMtu": {},
+        "/intel/snmp/interfaces/*/ifOperStatus": {},
+        "/intel/snmp/interfaces/*/ifOutDiscards": {},
+        "/intel/snmp/interfaces/*/ifOutErrors": {},
+        "/intel/snmp/interfaces/*/ifOutNUcastPkts": {},
+        "/intel/snmp/interfaces/*/ifOutQLen": {},
+        "/intel/snmp/interfaces/*/ifOutUcastPkts": {},
+        "/intel/snmp/interfaces/*/ifPhysAddress": {},
+        "/intel/snmp/interfaces/*/ifSpecific": {},
+        "/intel/snmp/interfaces/*/ifSpeed": {},
+        "/intel/snmp/interfaces/*/ifType": {}
+      },
+      "config": {
+        "/intel/snmp": {
+          "snmp_agent_name": "snmp_agent",
+          "snmp_agent_address": "127.0.0.1:161",
+          "snmp_version": "v2c",
+          "community": "public",
+          "network": "udp",
+          "timeout": 5,
+          "retries": 5
+        }
+      },
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_snmp_interfaces.txt"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Summary of changes:
- Exemplary setfile and task manifest to get stats for network interfaces

How to verify it:
- run Snap & SNMP plugin with this configuration

Testing done:
- manual tests

