### PR TITLE
Dynamic elements in metric namespace

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -256,11 +256,13 @@ func (p *Plugin) CollectMetrics(metrics []plugin.MetricType) ([]plugin.MetricTyp
 
 					//build namespace for metric
 					namespace := core.NewNamespace(vendor, pluginName)
-					for _, ns := range cfg.Namespace {
+					offset := len(namespace)
+					for j, ns := range cfg.Namespace {
 						if ns.Source == configReader.NsSourceString {
 							namespace = namespace.AddStaticElements(ns.String)
 						} else {
-							namespace = namespace.AddStaticElement(ns.Values[i])
+							namespace = namespace.AddDynamicElement(ns.Name, ns.Description)
+							namespace[j+offset].Value = ns.Values[i]
 						}
 					}
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -303,6 +303,22 @@ func TestCollectMetrics(t *testing.T) {
 				So(metrics[0].Data().(int64), ShouldEqual, 123)
 			})
 
+			Convey("when metric have dynamic namespace elements", func() {
+				snmp_ = &snmpMock{handlerEntry: snmpHandlerTestTable[SUCCESSFULLY_CREATED_HANDLER],
+					elementEntry: snmpElementTestTable[SNMP_ELEMENT_CORRECT_INTEGER]}
+
+				So(func() { plg.CollectMetrics(mts) }, ShouldNotPanic)
+				metrics, err := plg.CollectMetrics(mts)
+
+				So(err, ShouldBeNil)
+				So(metrics, ShouldNotBeEmpty)
+				isDynamic, dynamics := metrics[0].Namespace().IsDynamic()
+				So(isDynamic, ShouldEqual, true)
+				So(dynamics, ShouldHaveLength, 3)
+				So(dynamics, ShouldContain, 3)
+				So(dynamics, ShouldContain, 4)
+				So(dynamics, ShouldContain, 5)
+			})
 		})
 
 		Convey("when setfile content is incorrect - wrong `oid_part` parametr", func() {


### PR DESCRIPTION
**Problem fixed:**
When SNMP plugin collected metrics were publiched by OpenTSDB plugin, dynamic elements of namespace were not converted into tags

**Summary of changes:**
Problem was that all namespace elements of all metrics, returned from CollectMetrics function of SNMP plugin, were created as static.

**How to verify it:**
Having this config
```
snmp_setfile:
[
    {
        "mode": "table",
        "namespace": [
            {"source": "string", "string": "cisco"},
            {"source": "string", "string": "if-table"},
            {"source": "snmp", "name": "interface", "description": "interface name", "OID": ".1.3.6.1.2.1.2.2.1.2"},
            {"source": "index", "name": "id", "description": "interface index from OID", "oid_part": 10},
            {"source": "string", "string": "in_octets"}
        ],
        "OID": ".1.3.6.1.2.1.2.2.1.10",
        "scale": 1.0,
        "shift": 0,
        "unit": "octets",
        "description": "number of received octets"
    }
]
```

SNMP plugin collected metric

`/intel/snmp/cisco/if-table/GigabitEthernet0_1/2/in_octet`

will be published to OpenTSDB as

`intel.snmp.cisco.if-table.in_octets {interface=GigabitEthernet0__1, id=2}`